### PR TITLE
[AutoBot] [Idea] Stripe Renewal Slack Ping (source: Codex)

### DIFF
--- a/app/services/slack_digest.py
+++ b/app/services/slack_digest.py
@@ -69,15 +69,36 @@ class SlackDigestFormatter:
                 self._coerce_float(subscription.get("amount_due"), default=None)
             )
 
-            lines.append(
-                f"- `{subscription_id}` | {status} | renews {period_end} | {amount_text}"
-            )
+            line = f"- `{subscription_id}` | {status} | renews {period_end} | {amount_text}"
+            subscription_link = self._build_subscription_link(subscription)
+            if subscription_link:
+                line += f" | {subscription_link}"
+
+            lines.append(line)
 
         remaining = len(subscriptions) - max_lines
         if remaining > 0:
             lines.append(f"- ...and {remaining} more subscription{'s' if remaining != 1 else ''}")
 
         return lines
+
+    @staticmethod
+    def _build_subscription_link(subscription: Dict[str, Any]) -> str | None:
+        subscription_id = subscription.get("id")
+        if subscription_id is None:
+            return None
+
+        if isinstance(subscription_id, str):
+            subscription_id_str = subscription_id.strip()
+        else:
+            subscription_id_str = str(subscription_id).strip()
+
+        if not subscription_id_str:
+            return None
+
+        return (
+            f"<https://dashboard.stripe.com/subscriptions/{subscription_id_str}|View in Stripe>"
+        )
 
     @staticmethod
     def _as_string(value: Any, *, fallback: str) -> str:

--- a/tests/test_slack_digest_formatter.py
+++ b/tests/test_slack_digest_formatter.py
@@ -46,7 +46,9 @@ def test_format_digest_builds_slack_payload():
         "*3* upcoming subscriptions in the next 7 days | Projected total: $12,345.67"
     )
     assert blocks[1]["text"]["text"] == (
-        "- `sub_001` | active | renews 2024-06-01T00:00:00+00:00 | $4,999.00\n"
-        "- `sub_002` | past_due | renews 2024-06-02T00:00:00+00:00 | $1,500.50\n"
+        "- `sub_001` | active | renews 2024-06-01T00:00:00+00:00 | $4,999.00 | "
+        "<https://dashboard.stripe.com/subscriptions/sub_001|View in Stripe>\n"
+        "- `sub_002` | past_due | renews 2024-06-02T00:00:00+00:00 | $1,500.50 | "
+        "<https://dashboard.stripe.com/subscriptions/sub_002|View in Stripe>\n"
         "- ...and 1 more subscription"
     )


### PR DESCRIPTION
Automated implementation for issue #4.

Initial step: Add actionable Stripe dashboard links to Slack digest entries